### PR TITLE
add prompt from NiceGUI wiki to introduce the lib

### DIFF
--- a/prompt/prompt_template.py
+++ b/prompt/prompt_template.py
@@ -1,4 +1,60 @@
 developer_prompt_template = '''
+There is a new open-source Python library called NiceGUI. With NiceGUI you can write graphical user interfaces which run in the browser. It has a very gentle learning curve while still offering the option for advanced customizations. NiceGUI follows a backend-first philosophy: it handles all the web development details for you. You can focus on writing Python code. This makes it ideal for a wide range of projects including short scripts, dashboards, robotics projects, IoT solutions, smart home automation, and machine learning. Here is a short fully functional code example main.py:
+
+```
+from nicegui import ui
+ui.button('Click me', on_click=lambda: ui.notify(‘clicked’))
+ui.run()
+```
+
+Install with “pip install nicegui” and launch “python3 main.py”; it will open a new tab in your browser showing a button that when clicked, displays a snackbar notification.
+
+NiceGUI was initially built for accessing and controlling hardware like gpios, leds or usb devices. Over time it grew greatly beyond that. For example the website https://nicegui.io/ is itself running with NiceGUI. And with native mode, NiceGUI has Electron-like capabilities.
+The framework took much care to allow easy integration with any other Python library (unlike Streamlit).
+NiceGUI uses Vue/Quasar for the frontend and generates HTML/JS/CSS via templates on the fly. The backend is build on top FastAPI and uses socket.io for fast communication with the frontend. All user interactions are send to the backend and invoke the proper Python functions. Thereby it works best when there is a fast enough internet connection. Therefore is not meant to replace classical web apps; its main purpose is a quick way to build user interfaces for your Python code.
+
+# Main Features
+
+**Interaction:**
+buttons, switches, sliders, inputs, ...
+notifications, dialogs and menus
+keyboard input
+on-screen joystick
+
+**Layout:**
+navigation bars, tabs, panels, ...
+grouping with rows, columns and cards
+HTML and Markdown elements
+flex layout by default
+
+**Visualization:**
+charts, diagrams and tables
+3D scenes
+progress bars
+built-in timer for data refresh
+
+**Styling:**
+customizable color themes
+custom CSS and classes
+modern look with material design
+built-in Tailwind support
+
+**Coding:**
+live-cycle events
+implicit reload on code change (thanks to uvicorn)
+straight-forward data binding
+execute javascript from Python
+
+**Foundation:**
+generic Vue to Python bridge
+dynamic GUI through Quasar
+content is served with FastAPI
+Python 3.8+
+
+# Technical Details
+NiceGUI only uses one uvicorn worker (to not have to implement/support tricky synchronization).
+The socket.io library is used for managing web sockets. After the initial content is loaded a web socket connection is established and kept open for communication as long as the web page is shown. Each http request gets its own web socket connection.
+
 you are a 10 years python developer, you look up the document of nicegui which a python framework, here is the document:
 
 {summaries}


### PR DESCRIPTION
We have started maintaining an introduction prompt to help ChatGPT understand what NiceGUI is over at https://github.com/zauberzeug/nicegui/wiki#chatgpt. This pull requests simply adds the full prompt from https://github.com/zauberzeug/nicegui/wiki/Chat-GPT-4-Prompt to better prime the llm.